### PR TITLE
Clay 2335 Multiselect with Loading Indicator and Clear All Button

### DIFF
--- a/packages/clay-css/src/content/form_elements_input_groups.html
+++ b/packages/clay-css/src/content/form_elements_input_groups.html
@@ -795,8 +795,10 @@ section: Components
 				<label for="tagsField1">Tags</label>
 				<div class="input-group input-group-stacked-sm-down">
 					<div class="input-group-item">
-						<div class="form-control form-control-tag-group">
-							<input class="form-control-inset" id="tagsField1" type="text" value="some value">
+						<div class="form-control form-control-tag-group input-group">
+							<div class="input-group-item">
+								<input class="form-control-inset" id="tagsField1" type="text" value="some value">
+							</div>
 						</div>
 						<div class="form-feedback-group">
 							<div class="form-text">You can use a comma to enter tags. ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual.</div>
@@ -812,96 +814,8 @@ section: Components
 				<label for="tagsField2">Tags</label>
 				<div class="input-group input-group-stacked-sm-down">
 					<div class="input-group-item">
-						<div class="form-control form-control-tag-group">
-							<span class="label label-dismissible label-secondary" tabindex="0">
-								<span class="label-item label-item-before">
-									<span class="sticker">
-										<span class="sticker-overlay">
-											<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
-										</span>
-									</span>
-								</span>
-								<span class="label-item label-item-expand">wall</span>
-								<span class="label-item label-item-after">
-									<button aria-label="Close" class="close" tabindex="-1" type="button">
-										<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
-										</svg>
-									</button>
-								</span>
-							</span>
-							<span class="label label-dismissible label-secondary" tabindex="0">
-								<span class="label-item label-item-before">
-									<span class="sticker">
-										<span class="sticker-overlay">
-											<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
-										</span>
-									</span>
-								</span>
-								<span class="label-item label-item-expand">wallpaper</span>
-								<span class="label-item label-item-after">
-									<button aria-label="Close" class="close" tabindex="-1" type="button">
-										<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
-										</svg>
-									</button>
-								</span>
-							</span>
-							<span class="label label-dismissible label-secondary" tabindex="0">
-								<span class="label-item label-item-before">
-									<span class="sticker">
-										<span class="sticker-overlay">
-											<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
-										</span>
-									</span>
-								</span>
-								<span class="label-item label-item-expand">wonderwall</span>
-								<span class="label-item label-item-after">
-									<button aria-label="Close" class="close" tabindex="-1" type="button">
-										<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
-										</svg>
-									</button>
-								</span>
-							</span>
-							<span class="label label-dismissible label-secondary" tabindex="0">
-								<span class="label-item label-item-expand">winterfell</span>
-								<span class="label-item label-item-after">
-									<button aria-label="Close" class="close" tabindex="-1" type="button">
-										<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
-										</svg>
-									</button>
-								</span>
-							</span>
-							<span class="label label-dismissible label-secondary" tabindex="0">
-								<span class="label-item label-item-expand">ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAre</span>
-								<span class="label-item label-item-after">
-									<button aria-label="Close" class="close" tabindex="-1" type="button">
-										<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
-										</svg>
-									</button>
-								</span>
-							</span>
-							<input class="form-control-inset" id="tagsField2" type="text" value="some value">
-						</div>
-						<div class="form-feedback-group">
-							<div class="form-text">You can use a comma to enter tags. ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual.</div>
-						</div>
-					</div>
-					<div class="input-group-item input-group-item-shrink">
-						<button class="btn btn-secondary" type="button">Select All the Things</button>
-					</div>
-				</div>
-			</div>
-
-			<div class="form-group">
-				<label for="tagsField3">Tags</label>
-				<div class="input-group input-group-stacked-sm-down">
-					<div class="input-group-item">
-						<div class="dropdown">
-							<div class="form-control form-control-tag-group">
+						<div class="form-control form-control-tag-group input-group">
+							<div class="input-group-item">
 								<span class="label label-dismissible label-secondary" tabindex="0">
 									<span class="label-item label-item-before">
 										<span class="sticker">
@@ -973,7 +887,99 @@ section: Components
 										</button>
 									</span>
 								</span>
-								<input class="form-control-inset" id="tagsField3" type="text" value="some value">
+								<input class="form-control-inset" id="tagsField2" type="text" value="some value">
+							</div>
+						</div>
+						<div class="form-feedback-group">
+							<div class="form-text">You can use a comma to enter tags. ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual.</div>
+						</div>
+					</div>
+					<div class="input-group-item input-group-item-shrink">
+						<button class="btn btn-secondary" type="button">Select All the Things</button>
+					</div>
+				</div>
+			</div>
+
+			<div class="form-group">
+				<label for="tagsField3">Tags</label>
+				<div class="input-group input-group-stacked-sm-down">
+					<div class="input-group-item">
+						<div class="dropdown">
+							<div class="form-control form-control-tag-group input-group">
+								<div class="input-group-item">
+									<span class="label label-dismissible label-secondary" tabindex="0">
+										<span class="label-item label-item-before">
+											<span class="sticker">
+												<span class="sticker-overlay">
+													<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
+												</span>
+											</span>
+										</span>
+										<span class="label-item label-item-expand">wall</span>
+										<span class="label-item label-item-after">
+											<button aria-label="Close" class="close" tabindex="-1" type="button">
+												<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+													<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+												</svg>
+											</button>
+										</span>
+									</span>
+									<span class="label label-dismissible label-secondary" tabindex="0">
+										<span class="label-item label-item-before">
+											<span class="sticker">
+												<span class="sticker-overlay">
+													<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
+												</span>
+											</span>
+										</span>
+										<span class="label-item label-item-expand">wallpaper</span>
+										<span class="label-item label-item-after">
+											<button aria-label="Close" class="close" tabindex="-1" type="button">
+												<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+													<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+												</svg>
+											</button>
+										</span>
+									</span>
+									<span class="label label-dismissible label-secondary" tabindex="0">
+										<span class="label-item label-item-before">
+											<span class="sticker">
+												<span class="sticker-overlay">
+													<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
+												</span>
+											</span>
+										</span>
+										<span class="label-item label-item-expand">wonderwall</span>
+										<span class="label-item label-item-after">
+											<button aria-label="Close" class="close" tabindex="-1" type="button">
+												<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+													<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+												</svg>
+											</button>
+										</span>
+									</span>
+									<span class="label label-dismissible label-secondary" tabindex="0">
+										<span class="label-item label-item-expand">winterfell</span>
+										<span class="label-item label-item-after">
+											<button aria-label="Close" class="close" tabindex="-1" type="button">
+												<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+													<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+												</svg>
+											</button>
+										</span>
+									</span>
+									<span class="label label-dismissible label-secondary" tabindex="0">
+										<span class="label-item label-item-expand">ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAre</span>
+										<span class="label-item label-item-after">
+											<button aria-label="Close" class="close" tabindex="-1" type="button">
+												<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+													<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+												</svg>
+											</button>
+										</span>
+									</span>
+									<input class="form-control-inset" id="tagsField3" type="text" value="some value">
+								</div>
 							</div>
 							<ul class="autocomplete-dropdown-menu dropdown-menu show">
 								<li><a class="dropdown-item" href="#1">Some Value</a></li>
@@ -1016,9 +1022,11 @@ section: Components
 				<label for="tagsFieldContentEditable1">Tags (Content Editable)</label>
 				<div class="input-group input-group-stacked-sm-down">
 					<div class="input-group-item">
-						<div class="form-control form-control-tag-group">
-							<input aria-hidden="true" class="form-control-hidden" id="tagsFieldContentEditable1" tabindex="-1" type="text">
-							<span class="form-control-inset" contenteditable="true"></span>
+						<div class="form-control form-control-tag-group input-group">
+							<div class="input-group-item">
+								<input aria-hidden="true" class="form-control-hidden" id="tagsFieldContentEditable1" tabindex="-1" type="text">
+								<span class="form-control-inset" contenteditable="true"></span>
+							</div>
 						</div>
 						<div class="form-feedback-group">
 							<div class="form-text">You can use a comma to enter tags. ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual.</div>
@@ -1034,80 +1042,82 @@ section: Components
 				<label for="tagsContentEditableField2">Tags (Content Editable)</label>
 				<div class="input-group input-group-stacked-sm-down">
 					<div class="input-group-item">
-						<div class="form-control form-control-tag-group">
-							<span class="label label-dismissible label-secondary" tabindex="0">
-								<span class="label-item label-item-before">
-									<span class="sticker">
-										<span class="sticker-overlay">
-											<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
+						<div class="form-control form-control-tag-group input-group">
+							<div class="input-group-item">
+								<span class="label label-dismissible label-secondary" tabindex="0">
+									<span class="label-item label-item-before">
+										<span class="sticker">
+											<span class="sticker-overlay">
+												<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
+											</span>
 										</span>
 									</span>
-								</span>
-								<span class="label-item label-item-expand">wall</span>
-								<span class="label-item label-item-after">
-									<button aria-label="Close" class="close" tabindex="-1" type="button">
-										<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
-										</svg>
-									</button>
-								</span>
-							</span>
-							<span class="label label-dismissible label-secondary" tabindex="0">
-								<span class="label-item label-item-before">
-									<span class="sticker">
-										<span class="sticker-overlay">
-											<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
-										</span>
+									<span class="label-item label-item-expand">wall</span>
+									<span class="label-item label-item-after">
+										<button aria-label="Close" class="close" tabindex="-1" type="button">
+											<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+											</svg>
+										</button>
 									</span>
 								</span>
-								<span class="label-item label-item-expand">wallpaper</span>
-								<span class="label-item label-item-after">
-									<button aria-label="Close" class="close" tabindex="-1" type="button">
-										<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
-										</svg>
-									</button>
-								</span>
-							</span>
-							<span class="label label-dismissible label-secondary" tabindex="0">
-								<span class="label-item label-item-before">
-									<span class="sticker">
-										<span class="sticker-overlay">
-											<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
+								<span class="label label-dismissible label-secondary" tabindex="0">
+									<span class="label-item label-item-before">
+										<span class="sticker">
+											<span class="sticker-overlay">
+												<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
+											</span>
 										</span>
 									</span>
+									<span class="label-item label-item-expand">wallpaper</span>
+									<span class="label-item label-item-after">
+										<button aria-label="Close" class="close" tabindex="-1" type="button">
+											<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+											</svg>
+										</button>
+									</span>
 								</span>
-								<span class="label-item label-item-expand">wonderwall</span>
-								<span class="label-item label-item-after">
-									<button aria-label="Close" class="close" tabindex="-1" type="button">
-										<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
-										</svg>
-									</button>
+								<span class="label label-dismissible label-secondary" tabindex="0">
+									<span class="label-item label-item-before">
+										<span class="sticker">
+											<span class="sticker-overlay">
+												<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
+											</span>
+										</span>
+									</span>
+									<span class="label-item label-item-expand">wonderwall</span>
+									<span class="label-item label-item-after">
+										<button aria-label="Close" class="close" tabindex="-1" type="button">
+											<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+											</svg>
+										</button>
+									</span>
 								</span>
-							</span>
-							<span class="label label-dismissible label-secondary" tabindex="0">
-								<span class="label-item label-item-expand">winterfell</span>
-								<span class="label-item label-item-after">
-									<button aria-label="Close" class="close" tabindex="-1" type="button">
-										<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
-										</svg>
-									</button>
+								<span class="label label-dismissible label-secondary" tabindex="0">
+									<span class="label-item label-item-expand">winterfell</span>
+									<span class="label-item label-item-after">
+										<button aria-label="Close" class="close" tabindex="-1" type="button">
+											<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+											</svg>
+										</button>
+									</span>
 								</span>
-							</span>
-							<span class="label label-dismissible label-secondary" tabindex="0">
-								<span class="label-item label-item-expand">kings landing</span>
-								<span class="label-item label-item-after">
-									<button aria-label="Close" class="close" tabindex="-1" type="button">
-										<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-											<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
-										</svg>
-									</button>
+								<span class="label label-dismissible label-secondary" tabindex="0">
+									<span class="label-item label-item-expand">kings landing</span>
+									<span class="label-item label-item-after">
+										<button aria-label="Close" class="close" tabindex="-1" type="button">
+											<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+											</svg>
+										</button>
+									</span>
 								</span>
-							</span>
-							<input aria-hidden="true" class="form-control-hidden" id="tagsContentEditableField2" tabindex="-1" type="text">
-							<span class="form-control-inset" contenteditable>some value</span>
+								<input aria-hidden="true" class="form-control-hidden" id="tagsContentEditableField2" tabindex="-1" type="text">
+								<span class="form-control-inset" contenteditable>some value</span>
+							</div>
 						</div>
 						<div class="form-feedback-group">
 							<div class="form-text">You can use a comma to enter tags. ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual.</div>

--- a/packages/clay-css/src/content/form_elements_multiselect.html
+++ b/packages/clay-css/src/content/form_elements_multiselect.html
@@ -16,11 +16,9 @@ section: Components
 					<div class="input-group input-group-stacked-sm-down">
 						<div class="input-group-item">
 							<div class="dropdown">
-								<div class="form-control form-control-tag-group">
-									<span class="autofit-row">
-										<span class="autofit-col autofit-col-expand">
-											<input class="form-control-inset" id="tagsField1" type="text" value="some value">
-										</span>
+								<div class="form-control form-control-tag-group input-group">
+									<span class="input-group-item">
+										<input class="form-control-inset" id="tagsField1" type="text" value="some value">
 									</span>
 								</div>
 								<ul class="autocomplete-dropdown-menu dropdown-menu">
@@ -54,83 +52,81 @@ section: Components
 					<div class="input-group input-group-stacked-sm-down">
 						<div class="input-group-item">
 							<div class="dropdown">
-								<div class="form-control form-control-tag-group">
-									<span class="label label-dismissible label-secondary" tabindex="0">
-										<span class="label-item label-item-before">
-											<span class="sticker">
-												<span class="sticker-overlay">
-													<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
+								<div class="form-control form-control-tag-group input-group">
+									<div class="input-group-item">
+										<span class="label label-dismissible label-secondary" tabindex="0">
+											<span class="label-item label-item-before">
+												<span class="sticker">
+													<span class="sticker-overlay">
+														<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
+													</span>
 												</span>
 											</span>
-										</span>
-										<span class="label-item label-item-expand">wall</span>
-										<span class="label-item label-item-after">
-											<button aria-label="Close" class="close" tabindex="-1" type="button">
-												<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-													<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
-												</svg>
-											</button>
-										</span>
-									</span>
-									<span class="label label-dismissible label-secondary" tabindex="0">
-										<span class="label-item label-item-before">
-											<span class="sticker">
-												<span class="sticker-overlay">
-													<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
-												</span>
+											<span class="label-item label-item-expand">wall</span>
+											<span class="label-item label-item-after">
+												<button aria-label="Close" class="close" tabindex="-1" type="button">
+													<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+													</svg>
+												</button>
 											</span>
 										</span>
-										<span class="label-item label-item-expand">wallpaper</span>
-										<span class="label-item label-item-after">
-											<button aria-label="Close" class="close" tabindex="-1" type="button">
-												<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-													<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
-												</svg>
-											</button>
-										</span>
-									</span>
-									<span class="label label-dismissible label-secondary" tabindex="0">
-										<span class="label-item label-item-before">
-											<span class="sticker">
-												<span class="sticker-overlay">
-													<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
+										<span class="label label-dismissible label-secondary" tabindex="0">
+											<span class="label-item label-item-before">
+												<span class="sticker">
+													<span class="sticker-overlay">
+														<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
+													</span>
 												</span>
 											</span>
+											<span class="label-item label-item-expand">wallpaper</span>
+											<span class="label-item label-item-after">
+												<button aria-label="Close" class="close" tabindex="-1" type="button">
+													<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+													</svg>
+												</button>
+											</span>
 										</span>
-										<span class="label-item label-item-expand">wonderwall</span>
-										<span class="label-item label-item-after">
-											<button aria-label="Close" class="close" tabindex="-1" type="button">
-												<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-													<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
-												</svg>
-											</button>
+										<span class="label label-dismissible label-secondary" tabindex="0">
+											<span class="label-item label-item-before">
+												<span class="sticker">
+													<span class="sticker-overlay">
+														<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
+													</span>
+												</span>
+											</span>
+											<span class="label-item label-item-expand">wonderwall</span>
+											<span class="label-item label-item-after">
+												<button aria-label="Close" class="close" tabindex="-1" type="button">
+													<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+													</svg>
+												</button>
+											</span>
 										</span>
-									</span>
-									<span class="label label-dismissible label-secondary" tabindex="0">
-										<span class="label-item label-item-expand">winterfell</span>
-										<span class="label-item label-item-after">
-											<button aria-label="Close" class="close" tabindex="-1" type="button">
-												<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-													<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
-												</svg>
-											</button>
+										<span class="label label-dismissible label-secondary" tabindex="0">
+											<span class="label-item label-item-expand">winterfell</span>
+											<span class="label-item label-item-after">
+												<button aria-label="Close" class="close" tabindex="-1" type="button">
+													<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+													</svg>
+												</button>
+											</span>
 										</span>
-									</span>
-									<span class="label label-dismissible label-secondary" tabindex="0">
-										<span class="label-item label-item-expand">ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAre</span>
-										<span class="label-item label-item-after">
-											<button aria-label="Close" class="close" tabindex="-1" type="button">
-												<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-													<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
-												</svg>
-											</button>
+										<span class="label label-dismissible label-secondary" tabindex="0">
+											<span class="label-item label-item-expand">ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAre</span>
+											<span class="label-item label-item-after">
+												<button aria-label="Close" class="close" tabindex="-1" type="button">
+													<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+													</svg>
+												</button>
+											</span>
 										</span>
-									</span>
-									<span class="autofit-row">
-										<span class="autofit-col autofit-col-expand">
-											<input class="form-control-inset" id="tagsField2" type="text" value="some value">
-										</span>
-									</span>
+										<input class="form-control-inset" id="tagsField2" type="text" value="some value">
+									</div>
 								</div>
 								<ul class="autocomplete-dropdown-menu dropdown-menu">
 									<li><a class="dropdown-item" href="#1"><strong>some value</strong></a></li>
@@ -163,7 +159,294 @@ section: Components
 					<div class="input-group input-group-stacked-sm-down">
 						<div class="input-group-item">
 							<div class="dropdown">
-								<div class="form-control form-control-tag-group">
+								<div class="form-control form-control-tag-group input-group">
+									<div class="input-group-item">
+										<span class="label label-dismissible label-secondary" tabindex="0">
+											<span class="label-item label-item-before">
+												<span class="sticker">
+													<span class="sticker-overlay">
+														<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
+													</span>
+												</span>
+											</span>
+											<span class="label-item label-item-expand">wall</span>
+											<span class="label-item label-item-after">
+												<button aria-label="Close" class="close" tabindex="-1" type="button">
+													<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+													</svg>
+												</button>
+											</span>
+										</span>
+										<span class="label label-dismissible label-secondary" tabindex="0">
+											<span class="label-item label-item-before">
+												<span class="sticker">
+													<span class="sticker-overlay">
+														<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
+													</span>
+												</span>
+											</span>
+											<span class="label-item label-item-expand">wallpaper</span>
+											<span class="label-item label-item-after">
+												<button aria-label="Close" class="close" tabindex="-1" type="button">
+													<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+													</svg>
+												</button>
+											</span>
+										</span>
+										<span class="label label-dismissible label-secondary" tabindex="0">
+											<span class="label-item label-item-before">
+												<span class="sticker">
+													<span class="sticker-overlay">
+														<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
+													</span>
+												</span>
+											</span>
+											<span class="label-item label-item-expand">wonderwall</span>
+											<span class="label-item label-item-after">
+												<button aria-label="Close" class="close" tabindex="-1" type="button">
+													<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+													</svg>
+												</button>
+											</span>
+										</span>
+										<span class="label label-dismissible label-secondary" tabindex="0">
+											<span class="label-item label-item-expand">winterfell</span>
+											<span class="label-item label-item-after">
+												<button aria-label="Close" class="close" tabindex="-1" type="button">
+													<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+													</svg>
+												</button>
+											</span>
+										</span>
+										<span class="label label-dismissible label-secondary" tabindex="0">
+											<span class="label-item label-item-expand">ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAre</span>
+											<span class="label-item label-item-after">
+												<button aria-label="Close" class="close" tabindex="-1" type="button">
+													<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+													</svg>
+												</button>
+											</span>
+										</span>
+										<input class="form-control-inset" id="tagsField2" type="text" value="some value">
+									</div>
+									<div class="input-group-item input-group-item-shrink">
+										<span class="inline-item">
+											<span class="loading-animation" role="presentation"></span>
+										</span>
+									</div>
+									<div class="input-group-item input-group-item-shrink">
+										<a class="component-action" href="#1" role="button">
+											<svg class="lexicon-icon lexicon-icon-times-circle" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle"></use>
+											</svg>
+										</a>
+									</div>
+								</div>
+								<ul class="autocomplete-dropdown-menu dropdown-menu show">
+									<li><span class="disabled dropdown-item">Loading...</span></li>
+								</ul>
+							</div>
+
+							<div class="form-feedback-group">
+								<div class="form-text">You can use a comma to enter tags. ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual.</div>
+							</div>
+						</div>
+						<div class="input-group-item input-group-item-shrink">
+							<button class="btn btn-secondary" type="button">Select All the Things</button>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Clay Multiselect with Other Things</h3>
+
+		<div class="sheet">
+			<div class="form-group">
+				<div class="clay-multiselect">
+					<label for="tagsField3">Tags</label>
+					<div class="input-group input-group-stacked-sm-down">
+						<div class="input-group-item">
+							<div class="dropdown">
+								<div class="form-control form-control-tag-group input-group">
+									<div class="input-group-item input-group-item-shrink">
+										<button class="btn btn-warning" type="button">Warning</button>
+									</div>
+									<div class="input-group-item">
+										<span class="label label-dismissible label-secondary" tabindex="0">
+											<span class="label-item label-item-before">
+												<span class="sticker">
+													<span class="sticker-overlay">
+														<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
+													</span>
+												</span>
+											</span>
+											<span class="label-item label-item-expand">wall</span>
+											<span class="label-item label-item-after">
+												<button aria-label="Close" class="close" tabindex="-1" type="button">
+													<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+													</svg>
+												</button>
+											</span>
+										</span>
+										<span class="label label-dismissible label-secondary" tabindex="0">
+											<span class="label-item label-item-before">
+												<span class="sticker">
+													<span class="sticker-overlay">
+														<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
+													</span>
+												</span>
+											</span>
+											<span class="label-item label-item-expand">wallpaper</span>
+											<span class="label-item label-item-after">
+												<button aria-label="Close" class="close" tabindex="-1" type="button">
+													<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+													</svg>
+												</button>
+											</span>
+										</span>
+										<span class="label label-dismissible label-secondary" tabindex="0">
+											<span class="label-item label-item-before">
+												<span class="sticker">
+													<span class="sticker-overlay">
+														<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
+													</span>
+												</span>
+											</span>
+											<span class="label-item label-item-expand">wonderwall</span>
+											<span class="label-item label-item-after">
+												<button aria-label="Close" class="close" tabindex="-1" type="button">
+													<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+													</svg>
+												</button>
+											</span>
+										</span>
+										<span class="label label-dismissible label-secondary" tabindex="0">
+											<span class="label-item label-item-before">
+												<span class="sticker">
+													<span class="sticker-overlay">
+														<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
+													</span>
+												</span>
+											</span>
+											<span class="label-item label-item-expand">ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAre</span>
+											<span class="label-item label-item-after">
+												<button aria-label="Close" class="close" tabindex="-1" type="button">
+													<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+													</svg>
+												</button>
+											</span>
+										</span>
+
+										<span class="autofit-row">
+											<span class="autofit-col">
+												<button class="btn btn-primary" type="button">Button</button>
+											</span>
+											<span class="autofit-col autofit-col-expand">
+												<input class="form-control-inset" id="tagsField3" type="text" value="some value">
+											</span>
+											<span class="autofit-col">
+												<span class="inline-item">
+													<a href="#1">link</a>
+												</span>
+											</span>
+											<span class="autofit-col">
+												<button class="btn btn-monospaced btn-secondary" type="button">
+													<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+														<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+													</svg>
+												</button>
+											</span>
+										</span>
+									</div>
+									<div class="input-group-item input-group-item-shrink">
+										<span class="inline-item">
+											<span class="loading-animation" role="presentation"></span>
+										</span>
+									</div>
+									<div class="input-group-item input-group-item-shrink">
+										<a class="component-action" href="#1" role="button">
+											<svg class="lexicon-icon lexicon-icon-times-circle" focusable="false" role="presentation">
+												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle"></use>
+											</svg>
+										</a>
+									</div>
+								</div>
+								<ul class="autocomplete-dropdown-menu dropdown-menu">
+									<li><span class="disabled dropdown-item">Loading...</span></li>
+								</ul>
+							</div>
+
+							<div class="form-feedback-group">
+								<div class="form-text">You can use a comma to enter tags. ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual.</div>
+							</div>
+						</div>
+						<div class="input-group-item input-group-item-shrink">
+							<button class="btn btn-secondary" type="button">Select All the Things</button>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+
+	</div>
+</div>
+
+<div class="clay-site-row-spacer row">
+	<div class="col-md-12">
+		<h3>Clay Multiselect with Contenteditable Elements</h3>
+
+		<div class="sheet">
+			<div class="form-group">
+				<label for="formControlContentEditable1">Label (Content Editable)</label>
+
+				<div class="input-group input-group-stacked-sm-down">
+					<div class="input-group-item">
+						<div class="dropdown">
+							<div class="form-control form-control-tag-group input-group">
+								<div class="input-group-item">
+									<textarea aria-hidden="true" class="form-control-hidden" id="formControlContentEditable1" tabindex="-1"></textarea>
+									<div class="form-control-inset" contenteditable="true"></div>
+								</div>
+							</div>
+							<ul class="autocomplete-dropdown-menu dropdown-menu">
+								<li><a class="dropdown-item" href="#1"><strong>some value</strong></a></li>
+								<li><a class="dropdown-item" href="#1"><strong>some value</strong> meal</a></li>
+							</ul>
+						</div>
+						<div class="form-feedback-group">
+							<div class="form-text">You can use a comma to enter tags. ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual.</div>
+						</div>
+					</div>
+
+					<div class="input-group-item input-group-item-shrink">
+						<button class="btn btn-secondary" type="submit">Select</button>
+					</div>
+				</div>
+			</div>
+
+			<div class="form-group">
+				<label for="tagsContentEditableField2">Tags (Content Editable)</label>
+
+				<div class="input-group input-group-stacked-sm-down">
+					<div class="input-group-item">
+						<div class="dropdown">
+							<div class="form-control form-control-tag-group input-group">
+								<div class="input-group-item">
 									<span class="label label-dismissible label-secondary" tabindex="0">
 										<span class="label-item label-item-before">
 											<span class="sticker">
@@ -198,239 +481,9 @@ section: Components
 											</button>
 										</span>
 									</span>
-									<span class="label label-dismissible label-secondary" tabindex="0">
-										<span class="label-item label-item-before">
-											<span class="sticker">
-												<span class="sticker-overlay">
-													<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
-												</span>
-											</span>
-										</span>
-										<span class="label-item label-item-expand">wonderwall</span>
-										<span class="label-item label-item-after">
-											<button aria-label="Close" class="close" tabindex="-1" type="button">
-												<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-													<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
-												</svg>
-											</button>
-										</span>
-									</span>
-									<span class="label label-dismissible label-secondary" tabindex="0">
-										<span class="label-item label-item-expand">winterfell</span>
-										<span class="label-item label-item-after">
-											<button aria-label="Close" class="close" tabindex="-1" type="button">
-												<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-													<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
-												</svg>
-											</button>
-										</span>
-									</span>
-									<span class="label label-dismissible label-secondary" tabindex="0">
-										<span class="label-item label-item-expand">ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAre</span>
-										<span class="label-item label-item-after">
-											<button aria-label="Close" class="close" tabindex="-1" type="button">
-												<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-													<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
-												</svg>
-											</button>
-										</span>
-									</span>
-									<span class="autofit-row">
-										<span class="autofit-col autofit-col-expand">
-											<input class="form-control-inset" id="tagsField2" type="text" value="some value">
-										</span>
-										<span class="autofit-col">
-											<span class="inline-item">
-												<span class="loading-animation" role="presentation"></span>
-											</span>
-										</span>
-									</span>
+									<input aria-hidden="true" class="form-control-hidden" id="tagsContentEditableField2" tabindex="-1" type="text">
+									<span class="form-control-inset" contenteditable>some value</span>
 								</div>
-								<ul class="autocomplete-dropdown-menu dropdown-menu show">
-									<li><span class="disabled dropdown-item">Loading...</span></li>
-								</ul>
-							</div>
-
-							<div class="form-feedback-group">
-								<div class="form-text">You can use a comma to enter tags. ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual.</div>
-							</div>
-						</div>
-						<div class="input-group-item input-group-item-shrink">
-							<button class="btn btn-secondary" type="button">Select All the Things</button>
-						</div>
-					</div>
-				</div>
-			</div>
-		</div>
-
-	</div>
-</div>
-
-<div class="clay-site-row-spacer row">
-	<div class="col-md-12">
-		<h3>Clay Multiselect with Other Things</h3>
-
-		<div class="sheet">
-			<div class="form-group">
-				<div class="clay-multiselect">
-					<label for="tagsField3">Tags</label>
-					<div class="input-group input-group-stacked-sm-down">
-						<div class="input-group-item">
-							<div class="dropdown">
-								<div class="form-control form-control-tag-group">
-									<span class="label label-dismissible label-secondary" tabindex="0">
-										<span class="label-item label-item-before">
-											<span class="sticker">
-												<span class="sticker-overlay">
-													<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
-												</span>
-											</span>
-										</span>
-										<span class="label-item label-item-expand">wall</span>
-										<span class="label-item label-item-after">
-											<button aria-label="Close" class="close" tabindex="-1" type="button">
-												<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-													<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
-												</svg>
-											</button>
-										</span>
-									</span>
-									<span class="autofit-row">
-										<span class="autofit-col">
-											<a class="component-action" href="#1" role="button">
-												<svg class="lexicon-icon lexicon-icon-times-circle" focusable="false" role="presentation">
-													<use xlink:href="{{rootPath}}/images/icons/icons.svg#times-circle"></use>
-												</svg>
-											</a>
-										</span>
-										<span class="autofit-col autofit-col-expand">
-											<input class="form-control-inset" id="tagsField3" type="text" value="some value">
-										</span>
-										<span class="autofit-col">
-											<span class="inline-item">
-												<span class="loading-animation" role="presentation"></span>
-											</span>
-										</span>
-										<span class="autofit-col">
-											<span class="inline-item">
-												<a href="#1">link</a>
-											</span>
-										</span>
-										<span class="autofit-col">
-											<button class="btn btn-monospaced btn-secondary" type="button">
-												<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-													<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
-												</svg>
-											</button>
-										</span>
-										<span class="autofit-col">
-											<button class="btn btn-primary" type="button">Button</button>
-										</span>
-									</span>
-								</div>
-								<ul class="autocomplete-dropdown-menu dropdown-menu">
-									<li><span class="disabled dropdown-item">Loading...</span></li>
-								</ul>
-							</div>
-
-							<div class="form-feedback-group">
-								<div class="form-text">You can use a comma to enter tags. ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual.</div>
-							</div>
-						</div>
-						<div class="input-group-item input-group-item-shrink">
-							<button class="btn btn-secondary" type="button">Select All the Things</button>
-						</div>
-					</div>
-				</div>
-			</div>
-		</div>
-
-	</div>
-</div>
-
-<div class="clay-site-row-spacer row">
-	<div class="col-md-12">
-		<h3>Clay Multiselect with Contenteditable Elements</h3>
-
-		<div class="sheet">
-			<div class="form-group">
-				<label for="formControlContentEditable1">Label (Content Editable)</label>
-
-				<div class="input-group input-group-stacked-sm-down">
-					<div class="input-group-item">
-						<div class="dropdown">
-							<div class="form-control form-control-tag-group">
-								<span class="autofit-row">
-									<span class="autofit-col autofit-col-expand">
-										<textarea aria-hidden="true" class="form-control-hidden" id="formControlContentEditable1" tabindex="-1"></textarea>
-										<div class="form-control-inset" contenteditable="true"></div>
-									</span>
-								</span>
-							</div>
-							<ul class="autocomplete-dropdown-menu dropdown-menu">
-								<li><a class="dropdown-item" href="#1"><strong>some value</strong></a></li>
-								<li><a class="dropdown-item" href="#1"><strong>some value</strong> meal</a></li>
-							</ul>
-						</div>
-						<div class="form-feedback-group">
-							<div class="form-text">You can use a comma to enter tags. ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual.</div>
-						</div>
-					</div>
-
-					<div class="input-group-item input-group-item-shrink">
-						<button class="btn btn-secondary" type="submit">Select</button>
-					</div>
-				</div>
-			</div>
-
-			<div class="form-group">
-				<label for="tagsContentEditableField2">Tags (Content Editable)</label>
-
-				<div class="input-group input-group-stacked-sm-down">
-					<div class="input-group-item">
-						<div class="dropdown">
-							<div class="form-control form-control-tag-group">
-								<span class="label label-dismissible label-secondary" tabindex="0">
-									<span class="label-item label-item-before">
-										<span class="sticker">
-											<span class="sticker-overlay">
-												<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
-											</span>
-										</span>
-									</span>
-									<span class="label-item label-item-expand">wall</span>
-									<span class="label-item label-item-after">
-										<button aria-label="Close" class="close" tabindex="-1" type="button">
-											<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
-											</svg>
-										</button>
-									</span>
-								</span>
-								<span class="label label-dismissible label-secondary" tabindex="0">
-									<span class="label-item label-item-before">
-										<span class="sticker">
-											<span class="sticker-overlay">
-												<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
-											</span>
-										</span>
-									</span>
-									<span class="label-item label-item-expand">wallpaper</span>
-									<span class="label-item label-item-after">
-										<button aria-label="Close" class="close" tabindex="-1" type="button">
-											<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
-											</svg>
-										</button>
-									</span>
-								</span>
-
-								<span class="autofit-row">
-									<span class="autofit-col autofit-col-expand">
-										<input aria-hidden="true" class="form-control-hidden" id="tagsContentEditableField2" tabindex="-1" type="text">
-										<span class="form-control-inset" contenteditable>some value</span>
-									</span>
-								</span>
 							</div>
 							<ul class="autocomplete-dropdown-menu dropdown-menu">
 								<li><a class="dropdown-item" href="#1"><strong>some value</strong></a></li>
@@ -454,18 +507,16 @@ section: Components
 				<div class="input-group input-group-stacked-sm-down">
 					<div class="input-group-item">
 						<div class="dropdown">
-							<div class="form-control form-control-tag-group">
-								<span class="autofit-row">
-									<span class="autofit-col autofit-col-expand">
-										<input aria-hidden="true" class="form-control-hidden" id="formControlContentEditableLoading1" tabindex="-1" type="text">
-										<div class="form-control-inset" contenteditable="true"></div>
+							<div class="form-control form-control-tag-group input-group">
+								<div class="input-group-item">
+									<input aria-hidden="true" class="form-control-hidden" id="formControlContentEditableLoading1" tabindex="-1" type="text">
+									<div class="form-control-inset" contenteditable="true"></div>
+								</div>
+								<div class="input-group-item input-group-item-shrink">
+									<span class="inline-item">
+										<span class="loading-animation" role="presentation"></span>
 									</span>
-									<span class="autofit-col">
-										<span class="inline-item">
-											<span class="loading-animation" role="presentation"></span>
-										</span>
-									</span>
-								</span>
+								</div>
 							</div>
 							<ul class="autocomplete-dropdown-menu dropdown-menu">
 								<li><a class="dropdown-item" href="#1"><strong>some value</strong></a></li>
@@ -489,53 +540,51 @@ section: Components
 				<div class="input-group input-group-stacked-sm-down">
 					<div class="input-group-item">
 						<div class="dropdown">
-							<div class="form-control form-control-tag-group">
-								<span class="label label-dismissible label-secondary" tabindex="0">
-									<span class="label-item label-item-before">
-										<span class="sticker">
-											<span class="sticker-overlay">
-												<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
+							<div class="form-control form-control-tag-group input-group">
+								<div class="input-group-item">
+									<span class="label label-dismissible label-secondary" tabindex="0">
+										<span class="label-item label-item-before">
+											<span class="sticker">
+												<span class="sticker-overlay">
+													<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
+												</span>
 											</span>
 										</span>
-									</span>
-									<span class="label-item label-item-expand">wall</span>
-									<span class="label-item label-item-after">
-										<button aria-label="Close" class="close" tabindex="-1" type="button">
-											<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
-											</svg>
-										</button>
-									</span>
-								</span>
-								<span class="label label-dismissible label-secondary" tabindex="0">
-									<span class="label-item label-item-before">
-										<span class="sticker">
-											<span class="sticker-overlay">
-												<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
-											</span>
+										<span class="label-item label-item-expand">wall</span>
+										<span class="label-item label-item-after">
+											<button aria-label="Close" class="close" tabindex="-1" type="button">
+												<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+													<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+												</svg>
+											</button>
 										</span>
 									</span>
-									<span class="label-item label-item-expand">wallpaper</span>
-									<span class="label-item label-item-after">
-										<button aria-label="Close" class="close" tabindex="-1" type="button">
-											<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
-												<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
-											</svg>
-										</button>
+									<span class="label label-dismissible label-secondary" tabindex="0">
+										<span class="label-item label-item-before">
+											<span class="sticker">
+												<span class="sticker-overlay">
+													<img alt="thumbnail" class="sticker-img" src="../../images/thumbnail_dock.jpg">
+												</span>
+											</span>
+										</span>
+										<span class="label-item label-item-expand">wallpaper</span>
+										<span class="label-item label-item-after">
+											<button aria-label="Close" class="close" tabindex="-1" type="button">
+												<svg class="lexicon-icon lexicon-icon-times" focusable="false" role="presentation">
+													<use xlink:href="{{rootPath}}/images/icons/icons.svg#times"></use>
+												</svg>
+											</button>
+										</span>
 									</span>
-								</span>
 
-								<span class="autofit-row">
-									<span class="autofit-col autofit-col-expand">
-										<input aria-hidden="true" class="form-control-hidden" id="tagsContentEditableLoading2" tabindex="-1" type="text">
-										<span class="form-control-inset" contenteditable>some value</span>
+									<input aria-hidden="true" class="form-control-hidden" id="tagsContentEditableLoading2" tabindex="-1" type="text">
+									<span class="form-control-inset" contenteditable>some value</span>
+								</div>
+								<div class="input-group-item input-group-item-shrink">
+									<span class="inline-item">
+										<span class="loading-animation" role="presentation"></span>
 									</span>
-									<span class="autofit-col">
-										<span class="inline-item">
-											<span class="loading-animation" role="presentation"></span>
-										</span>
-									</span>
-								</span>
+								</div>
 							</div>
 							<ul class="autocomplete-dropdown-menu dropdown-menu">
 								<li><a class="dropdown-item" href="#1"><strong>some value</strong></a></li>

--- a/packages/clay-css/src/scss/components/_forms.scss
+++ b/packages/clay-css/src/scss/components/_forms.scss
@@ -194,6 +194,10 @@ div {
 		@include clay-container($form-control-tag-group-autofit-col);
 	}
 
+	.input-group-item {
+		@include clay-container($form-control-tag-group-input-group-item);
+	}
+
 	.inline-item {
 		@include clay-container($form-control-tag-group-inline-item);
 	}

--- a/packages/clay-css/src/scss/variables/_forms.scss
+++ b/packages/clay-css/src/scss/variables/_forms.scss
@@ -87,7 +87,7 @@ $form-control-tag-group: map-merge((
 
 $form-control-tag-group-autofit-row: () !default;
 $form-control-tag-group-autofit-row: map-merge((
-		align-items: flex-end,
+		align-items: center,
 		flex-grow: 1,
 		margin-left: -0.5rem,
 		margin-right: -0.5rem,
@@ -99,6 +99,11 @@ $form-control-tag-group-autofit-col: map-merge((
 	padding-left: 0.5rem,
 	padding-right: 0.5rem,
 ), $form-control-tag-group-autofit-col);
+
+$form-control-tag-group-input-group-item: () !default;
+$form-control-tag-group-input-group-item: map-merge((
+	align-items: flex-start,
+), $form-control-tag-group-input-group-item);
 
 $form-control-tag-group-inline-item: () !default;
 $form-control-tag-group-inline-item: map-merge((

--- a/packages/clay-management-toolbar/src/DefaultState.tsx
+++ b/packages/clay-management-toolbar/src/DefaultState.tsx
@@ -42,9 +42,23 @@ interface IProps extends IPropsBase {
 	onSortingButtonClick?: TClickEvent;
 
 	/**
+	 * Callback will always be called when the user clicks the search button
+	 * or press enter.
+	 */
+	onValueSubmit?: React.ComponentProps<typeof SearchInput>['onValueSubmit'];
+
+	/**
 	 * Set the value the user entered in search.
 	 */
 	searchValue?: string;
+
+	/**
+	 * Props to add to the form.
+	 */
+	searchFormProps?: Omit<
+		React.ComponentProps<typeof SearchForm>,
+		'onlySearch'
+	>;
 
 	/**
 	 * Set the link to the sorting order action, this will render a ClayLink
@@ -73,6 +87,8 @@ const DefaultState: React.FunctionComponent<IProps> = ({
 	onInfoButtonClick,
 	onSearchValueChange,
 	onSortingButtonClick,
+	onValueSubmit,
+	searchFormProps,
 	searchValue = '',
 	sortingOrder,
 	sortingURL,
@@ -174,18 +190,19 @@ const DefaultState: React.FunctionComponent<IProps> = ({
 				)}
 			</ItemList>
 
-			{onSearchValueChange && (
+			{onSearchValueChange && onValueSubmit && (
 				<div
 					className={classNames('navbar-form navbar-form-autofit', {
 						'navbar-overlay navbar-overlay-sm-down': !onlySearch,
 						show: searchMobile,
 					})}
 				>
-					<SearchForm onlySearch={onlySearch}>
+					<SearchForm {...searchFormProps} onlySearch={onlySearch}>
 						<SearchInput
 							disabled={disabled}
 							onCloseButtonClick={() => setSearchMobile(false)}
 							onValueChange={onSearchValueChange}
+							onValueSubmit={onValueSubmit}
 							onlySearch={onlySearch}
 							spritemap={spritemap}
 							value={searchValue}

--- a/packages/clay-management-toolbar/src/SearchForm.tsx
+++ b/packages/clay-management-toolbar/src/SearchForm.tsx
@@ -12,12 +12,11 @@ interface IProps extends React.FormHTMLAttributes<HTMLFormElement> {
 
 const SearchForm: React.FunctionComponent<IProps> = ({
 	children,
-	method = 'get',
 	onlySearch = false,
 	...otherProps
 }) => {
 	const content = (
-		<form {...otherProps} method={method} role="search">
+		<form {...otherProps} role="search">
 			{children}
 		</form>
 	);

--- a/packages/clay-management-toolbar/src/SearchInput.tsx
+++ b/packages/clay-management-toolbar/src/SearchInput.tsx
@@ -14,8 +14,14 @@ interface IProps {
 	onCloseButtonClick: (
 		event: React.MouseEvent<HTMLButtonElement, MouseEvent>
 	) => void;
-	onlySearch?: boolean;
 	onValueChange: (val: string) => void;
+	onValueSubmit: (
+		value: string,
+		event:
+			| React.MouseEvent<HTMLButtonElement, MouseEvent>
+			| React.KeyboardEvent<HTMLInputElement>
+	) => void;
+	onlySearch?: boolean;
 	spritemap?: string;
 	value: string;
 }
@@ -25,6 +31,7 @@ const SearchInput: React.FunctionComponent<IProps> = ({
 	disabled,
 	onCloseButtonClick,
 	onValueChange,
+	onValueSubmit,
 	onlySearch,
 	spritemap,
 	value,
@@ -36,6 +43,9 @@ const SearchInput: React.FunctionComponent<IProps> = ({
 				className="form-control input-group-inset input-group-inset-after"
 				disabled={disabled}
 				onChange={event => onValueChange(event.target.value)}
+				onKeyDown={event =>
+					event.key === 'Enter' && onValueSubmit(value, event)
+				}
 				type="text"
 				value={value}
 			/>
@@ -53,6 +63,7 @@ const SearchInput: React.FunctionComponent<IProps> = ({
 				<ClayButtonWithIcon
 					disabled={disabled}
 					displayType="unstyled"
+					onClick={event => onValueSubmit(value, event)}
 					spritemap={spritemap}
 					symbol="search"
 					type="submit"

--- a/packages/clay-management-toolbar/src/__tests__/BasicRendering.tsx
+++ b/packages/clay-management-toolbar/src/__tests__/BasicRendering.tsx
@@ -81,6 +81,7 @@ describe('BasicRendering', () => {
 		const {container} = render(
 			<ClayManagementToolbar
 				onSearchValueChange={() => {}}
+				onValueSubmit={() => {}}
 				searchValue=""
 				spritemap={spritemap}
 			/>
@@ -190,6 +191,7 @@ describe('BasicRendering', () => {
 				onCheckboxChange={() => {}}
 				onSearchValueChange={() => {}}
 				onSortingButtonClick={() => {}}
+				onValueSubmit={() => {}}
 				searchValue=""
 				sortingOrder="asc"
 				spritemap={spritemap}

--- a/packages/clay-management-toolbar/src/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/packages/clay-management-toolbar/src/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -2035,7 +2035,6 @@ exports[`BasicRendering renders a ManagementToolbar with disabled all 1`] = `
           class="container-fluid container-fluid-max-xl"
         >
           <form
-            method="get"
             role="search"
           >
             <div
@@ -2273,7 +2272,6 @@ exports[`BasicRendering renders a ManagementToolbar with only search 1`] = `
           class="container-fluid container-fluid-max-xl"
         >
           <form
-            method="get"
             role="search"
           >
             <div

--- a/packages/clay-management-toolbar/stories/index.tsx
+++ b/packages/clay-management-toolbar/stories/index.tsx
@@ -108,6 +108,10 @@ storiesOf('ClayManagementToolbar', module).add('default', () => {
 				boolean('Show select all button', true) ? () => {} : undefined
 			}
 			onSortingButtonClick={() => alert('Sorting button clicked')}
+			onValueSubmit={(value, event) => {
+				event.preventDefault();
+				alert(`Submit ${value}`);
+			}}
 			searchValue={value}
 			selectedItems={number('Selected items', 0)}
 			showResultsBar={boolean('Show ResultsBar', true)}

--- a/packages/clay-modal/package.json
+++ b/packages/clay-modal/package.json
@@ -29,7 +29,8 @@
 		"@clayui/button": "^3.0.0-milestone.3",
 		"@clayui/icon": "^3.0.0-milestone.3",
 		"@clayui/shared": "^3.0.0-milestone.3",
-		"classnames": "^2.2.6"
+		"classnames": "^2.2.6",
+		"warning": "^4.0.3"
 	},
 	"devDependencies": {
 		"@clayui/css": "^3.0.0-milestone.3"

--- a/packages/clay-modal/src/Header.tsx
+++ b/packages/clay-modal/src/Header.tsx
@@ -14,8 +14,8 @@ export type HeaderProps = HTMLAttributes<HTMLDivElement>;
 const ICON_MAP = {
 	danger: 'exclamation-full',
 	info: 'info-circle',
-	success: 'check-circle',
-	warning: 'question-circle-full',
+	success: 'check-circle-full',
+	warning: 'warning-full',
 };
 
 const ClayModalHeader: FunctionComponent<HeaderProps> = ({

--- a/packages/clay-modal/src/Modal.tsx
+++ b/packages/clay-modal/src/Modal.tsx
@@ -10,6 +10,7 @@ import Context, {IContext} from './Context';
 import Footer from './Footer';
 import Header from './Header';
 import React, {FunctionComponent, useEffect, useRef} from 'react';
+import warning from 'warning';
 import {ClayPortal} from '@clayui/shared';
 import {Observer, ObserverType, Size} from './types';
 import {useUserInteractions} from './Hook';
@@ -29,6 +30,17 @@ interface IProps
 	observer: Observer;
 }
 
+const warningMessage = `You need to pass the 'observer' prop to ClayModal for everything to work fine, use the 'useModal' hook that exposes the observer.
+
+> const {observer} = useModal({...});
+>
+> return (
+> 	<ClayModal observer={observer}>
+> 		...
+> 	</ClayModal>
+> ); 
+`;
+
 const ClayModal: FunctionComponent<IProps> & {
 	Body: typeof Body;
 	Footer: typeof Footer;
@@ -43,6 +55,8 @@ const ClayModal: FunctionComponent<IProps> & {
 	...otherProps
 }: IProps) => {
 	const modalBodyElementRef = useRef<HTMLDivElement | null>(null);
+
+	warning(observer !== undefined, warningMessage);
 
 	useUserInteractions(modalBodyElementRef, () =>
 		observer.dispatch(ObserverType.Close)

--- a/packages/clay-navigation-bar/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-navigation-bar/src/__tests__/__snapshots__/index.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ClayNavigationBar collapses the dropdown expanded when trigger element is clicked 1`] = `
+exports[`ClayNavigationBar collapses the previously expanded dropdown when trigger element is clicked 1`] = `
 <div
   class="navbar-collapse collapse"
   data-testid="NavigationBarDropdown"
@@ -46,90 +46,91 @@ exports[`ClayNavigationBar collapses the dropdown expanded when trigger element 
 `;
 
 exports[`ClayNavigationBar renders 1`] = `
-<nav
-  className="navbar navbar-collapse-absolute navbar-expand-md navbar-underline navigation-bar navigation-bar-secondary"
->
-  <div
-    className="container-fluid container-fluid-max-xl"
+<div>
+  <nav
+    class="navbar navbar-collapse-absolute navbar-expand-md navbar-underline navigation-bar navigation-bar-secondary"
   >
-    <a
-      aria-expanded={false}
-      className="navbar-toggler navbar-toggler-link collapsed link-secondary"
-      onClick={[Function]}
-    >
-      Item 1
-      <svg
-        className="lexicon-icon lexicon-icon-caret-bottom"
-        role="presentation"
-      >
-        <use
-          xlinkHref="node_modules/clay-css/lib/images/icons/icons.svg#caret-bottom"
-        />
-      </svg>
-    </a>
     <div
-      className="navbar-collapse collapse"
-      data-testid="NavigationBarDropdown"
-      onTransitionEnd={[Function]}
+      class="container-fluid container-fluid-max-xl"
     >
-      <div
-        className="container-fluid container-fluid-max-xl"
+      <a
+        aria-expanded="false"
+        class="navbar-toggler navbar-toggler-link collapsed link-secondary"
+        data-testid="navbarToggler"
       >
-        <ul
-          className="navbar-nav"
+        Item 1
+        <svg
+          class="lexicon-icon lexicon-icon-caret-bottom"
+          role="presentation"
         >
-          <li
-            className="nav-item"
+          <use
+            xlink:href="node_modules/clay-css/lib/images/icons/icons.svg#caret-bottom"
+          />
+        </svg>
+      </a>
+      <div
+        class="navbar-collapse collapse"
+        data-testid="NavigationBarDropdown"
+      >
+        <div
+          class="container-fluid container-fluid-max-xl"
+        >
+          <ul
+            class="navbar-nav"
           >
-            <a
-              className="nav-link active link-secondary"
-              href="#1"
+            <li
+              class="nav-item"
             >
-              <span
-                className="navbar-text-truncate"
+              <a
+                class="nav-link active link-secondary"
+                href="#1"
               >
-                Item 1
-              </span>
-            </a>
-          </li>
-          <li
-            className="nav-item"
-          >
-            <button
-              className="nav-link btn btn-block btn-sm btn-unstyled"
-              type="button"
+                <span
+                  class="navbar-text-truncate"
+                >
+                  Item 1
+                </span>
+              </a>
+            </li>
+            <li
+              class="nav-item"
             >
-              <span
-                className="navbar-text-truncate"
+              <button
+                class="nav-link btn btn-block btn-sm btn-unstyled"
+                type="button"
               >
-                Item 2
-              </span>
-            </button>
-          </li>
-          <li
-            className="nav-item"
-          >
-            <a
-              className="nav-link link-secondary"
-              href="#3"
+                <span
+                  class="navbar-text-truncate"
+                >
+                  Item 2
+                </span>
+              </button>
+            </li>
+            <li
+              class="nav-item"
             >
-              <span
-                className="navbar-text-truncate"
+              <a
+                class="nav-link link-secondary"
+                href="#3"
               >
-                Item 3
-              </span>
-            </a>
-          </li>
-        </ul>
+                <span
+                  class="navbar-text-truncate"
+                >
+                  Item 3
+                </span>
+              </a>
+            </li>
+          </ul>
+        </div>
       </div>
     </div>
-  </div>
-</nav>
+  </nav>
+</div>
 `;
 
-exports[`ClayNavigationBar renders a dropdown when clicking the collapsed element from NavigationBar 1`] = `
+exports[`ClayNavigationBar renders a dropdown when clicking the trigger element from NavigationBar 1`] = `
 <div
-  class="navbar-collapse collapse"
+  class="navbar-collapse collapse show"
   data-testid="NavigationBarDropdown"
   style=""
 >
@@ -173,85 +174,153 @@ exports[`ClayNavigationBar renders a dropdown when clicking the collapsed elemen
 `;
 
 exports[`ClayNavigationBar renders when passing more than one active item 1`] = `
-<nav
-  className="navbar navbar-collapse-absolute navbar-expand-md navbar-underline navigation-bar navigation-bar-secondary"
->
-  <div
-    className="container-fluid container-fluid-max-xl"
+<div>
+  <nav
+    class="navbar navbar-collapse-absolute navbar-expand-md navbar-underline navigation-bar navigation-bar-secondary"
   >
-    <a
-      aria-expanded={false}
-      className="navbar-toggler navbar-toggler-link collapsed link-secondary"
-      onClick={[Function]}
-    >
-      Item 1
-      <svg
-        className="lexicon-icon lexicon-icon-caret-bottom"
-        role="presentation"
-      >
-        <use
-          xlinkHref="node_modules/clay-css/lib/images/icons/icons.svg#caret-bottom"
-        />
-      </svg>
-    </a>
     <div
-      className="navbar-collapse collapse"
-      data-testid="NavigationBarDropdown"
-      onTransitionEnd={[Function]}
+      class="container-fluid container-fluid-max-xl"
     >
-      <div
-        className="container-fluid container-fluid-max-xl"
+      <a
+        aria-expanded="false"
+        class="navbar-toggler navbar-toggler-link collapsed link-secondary"
+        data-testid="navbarToggler"
       >
-        <ul
-          className="navbar-nav"
+        Item 1
+        <svg
+          class="lexicon-icon lexicon-icon-caret-bottom"
+          role="presentation"
         >
-          <li
-            className="nav-item"
+          <use
+            xlink:href="node_modules/clay-css/lib/images/icons/icons.svg#caret-bottom"
+          />
+        </svg>
+      </a>
+      <div
+        class="navbar-collapse collapse"
+        data-testid="NavigationBarDropdown"
+      >
+        <div
+          class="container-fluid container-fluid-max-xl"
+        >
+          <ul
+            class="navbar-nav"
           >
-            <a
-              className="nav-link link-secondary"
-              href="#1"
+            <li
+              class="nav-item"
             >
-              <span
-                className="navbar-text-truncate"
+              <a
+                class="nav-link link-secondary"
+                href="#1"
               >
-                Item 1
-              </span>
-            </a>
-          </li>
-          <li
-            className="nav-item"
-          >
-            <button
-              className="nav-link active btn btn-block btn-sm btn-unstyled"
-              type="button"
+                <span
+                  class="navbar-text-truncate"
+                >
+                  Item 1
+                </span>
+              </a>
+            </li>
+            <li
+              class="nav-item"
             >
-              <span
-                className="navbar-text-truncate"
+              <button
+                class="nav-link active btn btn-block btn-sm btn-unstyled"
+                type="button"
               >
-                Item 2
-              </span>
-            </button>
-          </li>
-          <li
-            className="nav-item"
-          >
-            <a
-              className="nav-link link-secondary"
-              href="#3"
+                <span
+                  class="navbar-text-truncate"
+                >
+                  Item 2
+                </span>
+              </button>
+            </li>
+            <li
+              class="nav-item"
             >
-              <span
-                className="navbar-text-truncate"
+              <a
+                class="nav-link link-secondary"
+                href="#3"
               >
-                Item 3
-              </span>
-            </a>
-          </li>
-        </ul>
+                <span
+                  class="navbar-text-truncate"
+                >
+                  Item 3
+                </span>
+              </a>
+            </li>
+          </ul>
+        </div>
       </div>
     </div>
-  </div>
-</nav>
+  </nav>
+</div>
 `;
 
-exports[`ClayNavigationBar should throw a warning when passing more than one active prop to child 1`] = `[Function]`;
+exports[`ClayNavigationBar should throw a warning when passing more than one active prop to child 1`] = `
+<div>
+  <nav
+    class="navbar navbar-collapse-absolute navbar-expand-md navbar-underline navigation-bar navigation-bar-secondary"
+  >
+    <div
+      class="container-fluid container-fluid-max-xl"
+    >
+      <a
+        aria-expanded="false"
+        class="navbar-toggler navbar-toggler-link collapsed link-secondary"
+        data-testid="navbarToggler"
+      >
+        Item 1
+        <svg
+          class="lexicon-icon lexicon-icon-caret-bottom"
+          role="presentation"
+        >
+          <use
+            xlink:href="node_modules/clay-css/lib/images/icons/icons.svg#caret-bottom"
+          />
+        </svg>
+      </a>
+      <div
+        class="navbar-collapse collapse"
+        data-testid="NavigationBarDropdown"
+      >
+        <div
+          class="container-fluid container-fluid-max-xl"
+        >
+          <ul
+            class="navbar-nav"
+          >
+            <li
+              class="nav-item"
+            >
+              <a
+                class="nav-link active link-secondary"
+                href="#1"
+              >
+                <span
+                  class="navbar-text-truncate"
+                >
+                  Item 1
+                </span>
+              </a>
+            </li>
+            <li
+              class="nav-item"
+            >
+              <button
+                class="nav-link active btn btn-block btn-sm btn-unstyled"
+                type="button"
+              >
+                <span
+                  class="navbar-text-truncate"
+                >
+                  Item 2
+                </span>
+              </button>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </nav>
+</div>
+`;

--- a/packages/clay-navigation-bar/src/__tests__/index.tsx
+++ b/packages/clay-navigation-bar/src/__tests__/index.tsx
@@ -4,16 +4,15 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import * as TestRenderer from 'react-test-renderer';
+import '@testing-library/jest-dom/extend-expect';
 import ClayButton from '@clayui/button';
 import ClayLink from '@clayui/link';
 import ClayNavigationBar from '..';
 import React from 'react';
 import {
 	act,
+	cleanup,
 	fireEvent,
-	getByTestId,
-	getByText,
 	render,
 	waitForElement,
 } from '@testing-library/react';
@@ -21,10 +20,12 @@ import {
 const spritemap = 'node_modules/clay-css/lib/images/icons/icons.svg';
 
 describe('ClayNavigationBar', () => {
+	afterEach(cleanup);
+
 	it('renders', () => {
 		const label = 'Item 1';
 
-		const testRenderer = TestRenderer.create(
+		const {container} = render(
 			<ClayNavigationBar
 				inverted
 				spritemap={spritemap}
@@ -63,7 +64,7 @@ describe('ClayNavigationBar', () => {
 			</ClayNavigationBar>
 		);
 
-		expect(testRenderer.toJSON()).toMatchSnapshot();
+		expect(container).toMatchSnapshot();
 	});
 
 	it('renders a dropdown when clicking the collapsed element from NavigationBar', async () => {
@@ -175,7 +176,7 @@ describe('ClayNavigationBar', () => {
 	it('renders when passing more than one active item', () => {
 		const label = 'Item 1';
 
-		const testRenderer = TestRenderer.create(
+		const {container} = render(
 			<ClayNavigationBar
 				inverted
 				spritemap={spritemap}
@@ -214,7 +215,7 @@ describe('ClayNavigationBar', () => {
 			</ClayNavigationBar>
 		);
 
-		expect(testRenderer.toJSON()).toMatchSnapshot();
+		expect(container).toMatchSnapshot();
 	});
 
 	it('should throw a warning when passing more than one active prop to child', () => {
@@ -224,7 +225,7 @@ describe('ClayNavigationBar', () => {
 
 		const label = 'Item 1';
 
-		const testRenderer = TestRenderer.create(
+		const {container} = render(
 			<ClayNavigationBar
 				inverted
 				spritemap={spritemap}
@@ -257,7 +258,7 @@ describe('ClayNavigationBar', () => {
 		expect(mockWarnings.mock.calls[0][0]).toBe(
 			'Warning: ClayNavigationBar expects 0 or 1 active children, but received 2'
 		);
-		expect(testRenderer.toJSON).toMatchSnapshot();
+		expect(container).toMatchSnapshot();
 		jest.resetAllMocks();
 	});
 });

--- a/packages/clay-navigation-bar/src/__tests__/index.tsx
+++ b/packages/clay-navigation-bar/src/__tests__/index.tsx
@@ -67,8 +67,8 @@ describe('ClayNavigationBar', () => {
 		expect(container).toMatchSnapshot();
 	});
 
-	it('renders a dropdown when clicking the collapsed element from NavigationBar', async () => {
-		const {container} = render(
+	it('renders a dropdown when clicking the trigger element from NavigationBar', async () => {
+		const {container, getByTestId, getByText} = render(
 			<ClayNavigationBar
 				inverted
 				spritemap={spritemap}
@@ -97,21 +97,14 @@ describe('ClayNavigationBar', () => {
 			</ClayNavigationBar>
 		);
 
-		fireEvent.click(getByText(container, 'Trigger Label'));
-		fireEvent.transitionEnd(
-			getByTestId(container, 'NavigationBarDropdown')
-		);
-
-		fireEvent.click(getByText(container, 'Trigger Label'));
-		fireEvent.transitionEnd(
-			getByTestId(container, 'NavigationBarDropdown')
-		);
+		fireEvent.click(getByText('Trigger Label'));
+		fireEvent.transitionEnd(getByTestId('NavigationBarDropdown'));
 
 		let navigationBarDropdown;
 
 		await act(async () => {
 			navigationBarDropdown = await waitForElement(() =>
-				getByTestId(container, 'NavigationBarDropdown')
+				container.querySelector('.navbar-collapse.collapse.show')
 			);
 		});
 
@@ -120,8 +113,8 @@ describe('ClayNavigationBar', () => {
 		expect(navigationBarDropdown).toMatchSnapshot();
 	});
 
-	it('collapses the dropdown expanded when trigger element is clicked', async () => {
-		const {container} = render(
+	it('collapses the previously expanded dropdown when trigger element is clicked', async () => {
+		const {container, getByTestId} = render(
 			<ClayNavigationBar
 				inverted
 				spritemap={spritemap}
@@ -150,25 +143,23 @@ describe('ClayNavigationBar', () => {
 			</ClayNavigationBar>
 		);
 
-		fireEvent.click(getByText(container, 'Trigger Label'));
-		fireEvent.transitionEnd(
-			getByTestId(container, 'NavigationBarDropdown')
-		);
+		fireEvent.click(getByTestId('navbarToggler'), 'Trigger Label');
+		fireEvent.transitionEnd(getByTestId('NavigationBarDropdown'));
 
-		fireEvent.click(getByText(container, 'Trigger Label'));
-		fireEvent.transitionEnd(
-			getByTestId(container, 'NavigationBarDropdown')
-		);
+		fireEvent.click(getByTestId('navbarToggler'), 'Trigger Label');
+		fireEvent.transitionEnd(getByTestId('NavigationBarDropdown'));
 
 		let navigationBarDropdown;
 
 		await act(async () => {
 			navigationBarDropdown = await waitForElement(() =>
-				getByTestId(container, 'NavigationBarDropdown')
+				container.querySelector('.navbar-collapse.collapse')
 			);
 		});
 
 		expect(navigationBarDropdown).toBeDefined();
+
+		expect(navigationBarDropdown).not.toHaveClass('show');
 
 		expect(navigationBarDropdown).toMatchSnapshot();
 	});

--- a/packages/clay-navigation-bar/src/index.tsx
+++ b/packages/clay-navigation-bar/src/index.tsx
@@ -86,6 +86,7 @@ const ClayNavigationBar: React.FunctionComponent<IProps> & {
 							collapsed: !visible,
 						}
 					)}
+					data-testid="navbarToggler"
 					displayType="secondary"
 					onClick={handleClickToggler}
 				>

--- a/packages/clay-navigation-bar/stories/index.tsx
+++ b/packages/clay-navigation-bar/stories/index.tsx
@@ -14,36 +14,50 @@ import {storiesOf} from '@storybook/react';
 
 const spritemap = require('@clayui/css/lib/images/icons/icons.svg');
 
-storiesOf('ClayNavigationBar', module).add('default', () => (
-	<ClayNavigationBar
-		inverted={boolean('Inverted: ', false)}
-		spritemap={spritemap}
-		triggerLabel={text('triggerLabel: ', 'Item 1')}
-	>
-		<ClayNavigationBar.Item active={boolean('Active 1: ', true)}>
-			<ClayLink className="nav-link" displayType="secondary" href="#1">
-				<span className="navbar-text-truncate">{`Item 1`}</span>
-			</ClayLink>
-		</ClayNavigationBar.Item>
+storiesOf('ClayNavigationBar', module).add('default', () => {
+	const [triggerName, setTriggerName] = React.useState<string>('Item 1');
+	return (
+		<ClayNavigationBar
+			inverted={boolean('Inverted: ', false)}
+			spritemap={spritemap}
+			triggerLabel={text('triggerLabel: ', triggerName)}
+		>
+			<ClayNavigationBar.Item active={boolean('Active 1: ', true)}>
+				<ClayLink
+					className="nav-link"
+					displayType="secondary"
+					href="#1"
+				>
+					<span className="navbar-text-truncate">{`Item 1`}</span>
+				</ClayLink>
+			</ClayNavigationBar.Item>
 
-		<ClayNavigationBar.Item active={boolean('Active 2: ', false)}>
-			<ClayButton block className="nav-link" displayType="unstyled" small>
-				<span className="navbar-text-truncate">{`Item 2`}</span>
-			</ClayButton>
-		</ClayNavigationBar.Item>
+			<ClayNavigationBar.Item active={boolean('Active 2: ', false)}>
+				<ClayButton
+					block
+					className="nav-link"
+					displayType="unstyled"
+					onClick={() => setTriggerName('Item 2')}
+					small
+				>
+					<span className="navbar-text-truncate">{`Item 2`}</span>
+				</ClayButton>
+			</ClayNavigationBar.Item>
 
-		<ClayNavigationBar.Item active={boolean('Active 3: ', false)}>
-			<a className="nav-link link-secondary" href="#1">
-				<span className="navbar-text-truncate">{`Item 3`}</span>
-			</a>
-		</ClayNavigationBar.Item>
-		<ClayNavigationBar.Item active={boolean('Active 4: ', false)}>
-			<button
-				className="nav-link btn btn-unstyled btn-block btn-sm"
-				type="button"
-			>
-				<span className="navbar-text-truncate">{`Item 4`}</span>
-			</button>
-		</ClayNavigationBar.Item>
-	</ClayNavigationBar>
-));
+			<ClayNavigationBar.Item active={boolean('Active 3: ', false)}>
+				<a className="nav-link link-secondary" href="#1">
+					<span className="navbar-text-truncate">{`Item 3`}</span>
+				</a>
+			</ClayNavigationBar.Item>
+			<ClayNavigationBar.Item active={boolean('Active 4: ', false)}>
+				<button
+					className="nav-link btn btn-unstyled btn-block btn-sm"
+					onClick={() => setTriggerName('Item 4')}
+					type="button"
+				>
+					<span className="navbar-text-truncate">{`Item 4`}</span>
+				</button>
+			</ClayNavigationBar.Item>
+		</ClayNavigationBar>
+	);
+});

--- a/packages/clay-table/src/Cell.tsx
+++ b/packages/clay-table/src/Cell.tsx
@@ -66,7 +66,7 @@ const ClayTableCell: React.FunctionComponent<ICellProps> = ({
 	expanded,
 	headingCell = false,
 	headingTitle = false,
-	truncate = true,
+	truncate = false,
 	...otherProps
 }: ICellProps) => {
 	const TagName = headingCell ? 'th' : 'td';

--- a/packages/clay-table/src/Cell.tsx
+++ b/packages/clay-table/src/Cell.tsx
@@ -49,6 +49,12 @@ interface ICellProps extends TableCellBaseProps {
 	 * header cell element.
 	 */
 	headingTitle?: boolean;
+
+	/**
+	 * Truncates the text inside a Cell. Requires `expanded`
+	 * property value set to true.
+	 */
+	truncate?: boolean;
 }
 
 const ClayTableCell: React.FunctionComponent<ICellProps> = ({
@@ -60,6 +66,7 @@ const ClayTableCell: React.FunctionComponent<ICellProps> = ({
 	expanded,
 	headingCell = false,
 	headingTitle = false,
+	truncate = true,
 	...otherProps
 }: ICellProps) => {
 	const TagName = headingCell ? 'th' : 'td';
@@ -74,13 +81,19 @@ const ClayTableCell: React.FunctionComponent<ICellProps> = ({
 				[`text-${align}`]: align,
 			})}
 		>
-			{headingTitle
-				? React.Children.map(children, (child, i) => (
-						<p className="table-list-title" key={i}>
-							{child}
-						</p>
-				  ))
-				: children}
+			{headingTitle ? (
+				React.Children.map(children, (child, i) => (
+					<p className="table-list-title" key={i}>
+						{child}
+					</p>
+				))
+			) : truncate ? (
+				<span className="text-truncate-inline">
+					<span className="text-truncate">{children}</span>
+				</span>
+			) : (
+				children
+			)}
 		</TagName>
 	);
 };

--- a/packages/clay-table/src/Cell.tsx
+++ b/packages/clay-table/src/Cell.tsx
@@ -75,7 +75,7 @@ const ClayTableCell: React.FunctionComponent<ICellProps> = ({
 		<TagName
 			{...otherProps}
 			className={classNames(className, {
-				'table-cell-expand': expanded,
+				'table-cell-expand': expanded || truncate,
 				[`table-cell-${cellDelimiter}`]: cellDelimiter,
 				[`table-column-text-${columnTextAlignment}`]: columnTextAlignment,
 				[`text-${align}`]: align,
@@ -87,7 +87,7 @@ const ClayTableCell: React.FunctionComponent<ICellProps> = ({
 						{child}
 					</p>
 				))
-			) : truncate ? (
+			) : truncate && typeof children === 'string' ? (
 				<span className="text-truncate-inline">
 					<span className="text-truncate">{children}</span>
 				</span>

--- a/packages/clay-table/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-table/src/__tests__/__snapshots__/index.tsx.snap
@@ -25,12 +25,20 @@ exports[`ClayTable renders a Cell delimited 1`] = `
           class=""
         >
           <th
-            class="table-cell-start"
+            class="table-cell-expand table-cell-start"
           >
-            Start
+            <span
+              class="text-truncate-inline"
+            >
+              <span
+                class="text-truncate"
+              >
+                Start
+              </span>
+            </span>
           </th>
           <th
-            class=""
+            class="table-cell-expand"
           >
             <button
               type="button"
@@ -39,7 +47,7 @@ exports[`ClayTable renders a Cell delimited 1`] = `
             </button>
           </th>
           <th
-            class=""
+            class="table-cell-expand"
           >
             <button
               type="button"
@@ -48,9 +56,17 @@ exports[`ClayTable renders a Cell delimited 1`] = `
             </button>
           </th>
           <th
-            class="table-cell-end"
+            class="table-cell-expand table-cell-end"
           >
-            End
+            <span
+              class="text-truncate-inline"
+            >
+              <span
+                class="text-truncate"
+              >
+                End
+              </span>
+            </span>
           </th>
         </tr>
       </thead>
@@ -72,7 +88,7 @@ exports[`ClayTable renders a Cell with text alignment set to center 1`] = `
           class=""
         >
           <th
-            class="text-center"
+            class="table-cell-expand text-center"
           >
             <a
               href="#1"
@@ -267,12 +283,20 @@ exports[`ClayTable renders a table with multiple Cells into Row 1`] = `
           class=""
         >
           <td
-            class=""
+            class="table-cell-expand"
           >
-            One
+            <span
+              class="text-truncate-inline"
+            >
+              <span
+                class="text-truncate"
+              >
+                One
+              </span>
+            </span>
           </td>
           <td
-            class=""
+            class="table-cell-expand"
           >
             <button
               type="button"
@@ -281,9 +305,17 @@ exports[`ClayTable renders a table with multiple Cells into Row 1`] = `
             </button>
           </td>
           <td
-            class=""
+            class="table-cell-expand"
           >
-            Three
+            <span
+              class="text-truncate-inline"
+            >
+              <span
+                class="text-truncate"
+              >
+                Three
+              </span>
+            </span>
           </td>
         </tr>
       </tbody>
@@ -353,10 +385,18 @@ exports[`ClayTable renders with a headingTitle 1`] = `
           class="table-divider"
         >
           <td
-            class=""
+            class="table-cell-expand"
             colspan="8"
           >
-            Recipes
+            <span
+              class="text-truncate-inline"
+            >
+              <span
+                class="text-truncate"
+              >
+                Recipes
+              </span>
+            </span>
           </td>
         </tr>
         <tr
@@ -372,17 +412,33 @@ exports[`ClayTable renders with a headingTitle 1`] = `
             </p>
           </td>
           <td
-            class=""
+            class="table-cell-expand"
           />
           <td
-            class=""
+            class="table-cell-expand"
           >
-            U.S.A
+            <span
+              class="text-truncate-inline"
+            >
+              <span
+                class="text-truncate"
+              >
+                U.S.A
+              </span>
+            </span>
           </td>
           <td
-            class="text-right"
+            class="table-cell-expand text-right"
           >
-            10 min.
+            <span
+              class="text-truncate-inline"
+            >
+              <span
+                class="text-truncate"
+              >
+                10 min.
+              </span>
+            </span>
           </td>
         </tr>
       </tbody>

--- a/packages/clay-table/src/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/clay-table/src/__tests__/__snapshots__/index.tsx.snap
@@ -25,20 +25,12 @@ exports[`ClayTable renders a Cell delimited 1`] = `
           class=""
         >
           <th
-            class="table-cell-expand table-cell-start"
+            class="table-cell-start"
           >
-            <span
-              class="text-truncate-inline"
-            >
-              <span
-                class="text-truncate"
-              >
-                Start
-              </span>
-            </span>
+            Start
           </th>
           <th
-            class="table-cell-expand"
+            class=""
           >
             <button
               type="button"
@@ -47,7 +39,7 @@ exports[`ClayTable renders a Cell delimited 1`] = `
             </button>
           </th>
           <th
-            class="table-cell-expand"
+            class=""
           >
             <button
               type="button"
@@ -56,17 +48,9 @@ exports[`ClayTable renders a Cell delimited 1`] = `
             </button>
           </th>
           <th
-            class="table-cell-expand table-cell-end"
+            class="table-cell-end"
           >
-            <span
-              class="text-truncate-inline"
-            >
-              <span
-                class="text-truncate"
-              >
-                End
-              </span>
-            </span>
+            End
           </th>
         </tr>
       </thead>
@@ -88,7 +72,7 @@ exports[`ClayTable renders a Cell with text alignment set to center 1`] = `
           class=""
         >
           <th
-            class="table-cell-expand text-center"
+            class="text-center"
           >
             <a
               href="#1"
@@ -283,20 +267,12 @@ exports[`ClayTable renders a table with multiple Cells into Row 1`] = `
           class=""
         >
           <td
-            class="table-cell-expand"
+            class=""
           >
-            <span
-              class="text-truncate-inline"
-            >
-              <span
-                class="text-truncate"
-              >
-                One
-              </span>
-            </span>
+            One
           </td>
           <td
-            class="table-cell-expand"
+            class=""
           >
             <button
               type="button"
@@ -305,17 +281,9 @@ exports[`ClayTable renders a table with multiple Cells into Row 1`] = `
             </button>
           </td>
           <td
-            class="table-cell-expand"
+            class=""
           >
-            <span
-              class="text-truncate-inline"
-            >
-              <span
-                class="text-truncate"
-              >
-                Three
-              </span>
-            </span>
+            Three
           </td>
         </tr>
       </tbody>
@@ -385,18 +353,10 @@ exports[`ClayTable renders with a headingTitle 1`] = `
           class="table-divider"
         >
           <td
-            class="table-cell-expand"
+            class=""
             colspan="8"
           >
-            <span
-              class="text-truncate-inline"
-            >
-              <span
-                class="text-truncate"
-              >
-                Recipes
-              </span>
-            </span>
+            Recipes
           </td>
         </tr>
         <tr
@@ -412,33 +372,17 @@ exports[`ClayTable renders with a headingTitle 1`] = `
             </p>
           </td>
           <td
-            class="table-cell-expand"
+            class=""
           />
           <td
-            class="table-cell-expand"
+            class=""
           >
-            <span
-              class="text-truncate-inline"
-            >
-              <span
-                class="text-truncate"
-              >
-                U.S.A
-              </span>
-            </span>
+            U.S.A
           </td>
           <td
-            class="table-cell-expand text-right"
+            class="text-right"
           >
-            <span
-              class="text-truncate-inline"
-            >
-              <span
-                class="text-truncate"
-              >
-                10 min.
-              </span>
-            </span>
+            10 min.
           </td>
         </tr>
       </tbody>

--- a/packages/clay-table/stories/index.tsx
+++ b/packages/clay-table/stories/index.tsx
@@ -85,6 +85,9 @@ storiesOf('ClayTable', module)
 					<ClayTable.Cell headingCell headingTitle>
 						{'Country'}
 					</ClayTable.Cell>
+					<ClayTable.Cell headingCell headingTitle>
+						{'Description'}
+					</ClayTable.Cell>
 				</ClayTable.Row>
 			</ClayTable.Head>
 			<ClayTable.Body>
@@ -94,6 +97,11 @@ storiesOf('ClayTable', module)
 					</ClayTable.Cell>
 					<ClayTable.Cell>{'South America'}</ClayTable.Cell>
 					<ClayTable.Cell>{'Brazil'}</ClayTable.Cell>
+					<ClayTable.Cell>
+						{
+							'Homero aeterno conclusionemque est in, scribentur mediocritatem mea ut. Ad voluptua vituperata constituam pro. Mel at constituto efficiantur, in eirmod lobortis mei. Eam vero probo efficiendi ne, molestie pericula nec in, dolore minimum duo et. Mundi epicuri patrioque in vis, virtute legimus oporteat cu eum.'
+						}
+					</ClayTable.Cell>
 				</ClayTable.Row>
 				<ClayTable.Row>
 					<ClayTable.Cell headingTitle>
@@ -101,6 +109,11 @@ storiesOf('ClayTable', module)
 					</ClayTable.Cell>
 					<ClayTable.Cell>{'Europe'}</ClayTable.Cell>
 					<ClayTable.Cell>{'Spain'}</ClayTable.Cell>
+					<ClayTable.Cell>
+						{
+							'Homero aeterno conclusionemque est in, scribentur mediocritatem mea ut. Ad voluptua vituperata constituam pro. Mel at constituto efficiantur, in eirmod lobortis mei. Eam vero probo efficiendi ne, molestie pericula nec in, dolore minimum duo et. Mundi epicuri patrioque in vis, virtute legimus oporteat cu eum.'
+						}
+					</ClayTable.Cell>
 				</ClayTable.Row>
 			</ClayTable.Body>
 		</ClayTable>
@@ -124,10 +137,10 @@ storiesOf('ClayTable', module)
 						<span className="text-truncate-inline">
 							<span
 								className="text-truncate"
-								title="Wings eu, pumpkin spice robusta, kopi-luwak mocha caffeine froth grounds."
+								title="Homero aeterno conclusionemque est in, scribentur mediocritatem mea ut. Ad voluptua vituperata constituam pro. Mel at constituto efficiantur, in eirmod lobortis mei. Eam vero probo efficiendi ne, molestie pericula nec in, dolore minimum duo et. Mundi epicuri patrioque in vis, virtute legimus oporteat cu eum."
 							>
 								{
-									'Wings eu, pumpkin spice robusta, kopi-luwak mocha caffeine froth grounds.'
+									'Homero aeterno conclusionemque est in, scribentur mediocritatem mea ut. Ad voluptua vituperata constituam pro. Mel at constituto efficiantur, in eirmod lobortis mei. Eam vero probo efficiendi ne, molestie pericula nec in, dolore minimum duo et. Mundi epicuri patrioque in vis, virtute legimus oporteat cu eum.'
 								}
 							</span>
 						</span>

--- a/packages/clay-table/stories/index.tsx
+++ b/packages/clay-table/stories/index.tsx
@@ -97,7 +97,7 @@ storiesOf('ClayTable', module)
 					</ClayTable.Cell>
 					<ClayTable.Cell>{'South America'}</ClayTable.Cell>
 					<ClayTable.Cell>{'Brazil'}</ClayTable.Cell>
-					<ClayTable.Cell>
+					<ClayTable.Cell truncate>
 						{
 							'Homero aeterno conclusionemque est in, scribentur mediocritatem mea ut. Ad voluptua vituperata constituam pro. Mel at constituto efficiantur, in eirmod lobortis mei. Eam vero probo efficiendi ne, molestie pericula nec in, dolore minimum duo et. Mundi epicuri patrioque in vis, virtute legimus oporteat cu eum.'
 						}
@@ -109,7 +109,7 @@ storiesOf('ClayTable', module)
 					</ClayTable.Cell>
 					<ClayTable.Cell>{'Europe'}</ClayTable.Cell>
 					<ClayTable.Cell>{'Spain'}</ClayTable.Cell>
-					<ClayTable.Cell>
+					<ClayTable.Cell truncate>
 						{
 							'Homero aeterno conclusionemque est in, scribentur mediocritatem mea ut. Ad voluptua vituperata constituam pro. Mel at constituto efficiantur, in eirmod lobortis mei. Eam vero probo efficiendi ne, molestie pericula nec in, dolore minimum duo et. Mundi epicuri patrioque in vis, virtute legimus oporteat cu eum.'
 						}
@@ -489,12 +489,10 @@ storiesOf('ClayTable', module)
 						<ClayTable.Cell>
 							<ClayCheckboxWithState />
 						</ClayTable.Cell>
-						<ClayTable.Cell expanded headingTitle>
-							<span className="text-truncate">
-								{
-									'Wings eu, pumpkin spice robusta, kopi-luwak mocha caffeine froth grounds.'
-								}
-							</span>
+						<ClayTable.Cell headingTitle truncate>
+							{
+								'Wings eu, pumpkin spice robusta, kopi-luwak mocha caffeine froth grounds.'
+							}
 						</ClayTable.Cell>
 						<ClayTable.Cell>
 							<a href="1">{'JPG'}</a>
@@ -510,12 +508,10 @@ storiesOf('ClayTable', module)
 						<ClayTable.Cell>
 							<ClayCheckboxWithState />
 						</ClayTable.Cell>
-						<ClayTable.Cell expanded headingTitle>
-							<span className="text-truncate">
-								{
-									'Wings eu, pumpkin spice robusta, kopi-luwak mocha caffeine froth grounds.'
-								}
-							</span>
+						<ClayTable.Cell headingTitle truncate>
+							{
+								'Wings eu, pumpkin spice robusta, kopi-luwak mocha caffeine froth grounds.'
+							}
 						</ClayTable.Cell>
 						<ClayTable.Cell>
 							<a href="2">{'GIF'}</a>
@@ -531,12 +527,10 @@ storiesOf('ClayTable', module)
 						<ClayTable.Cell>
 							<ClayCheckboxWithState />
 						</ClayTable.Cell>
-						<ClayTable.Cell expanded headingTitle>
-							<span className="text-truncate">
-								{
-									'Wings eu, pumpkin spice robusta, kopi-luwak mocha caffeine froth grounds.'
-								}
-							</span>
+						<ClayTable.Cell headingTitle truncate>
+							{
+								'Wings eu, pumpkin spice robusta, kopi-luwak mocha caffeine froth grounds.'
+							}
 						</ClayTable.Cell>
 						<ClayTable.Cell>
 							<a href="3">{'TIFF'}</a>


### PR DESCRIPTION
Hey @matuzalemsteles, I've updated the markup to position the loading indicator and clear all button. The markup is:
```
<div class="clay-multiselect">
	<label for="myId">Tags</label>
	<div class="input-group input-group-stacked-sm-down">
		<div class="input-group-item">
			<div class="dropdown">
				<div class="form-control form-control-tag-group input-group">
					<div class="input-group-item">
						<span class="label label-dismissible label-secondary" tabindex="0">...</span>
						<input class="form-control-inset" id="myId" type="text" value="">
					</div>
					<div class="input-group-item input-group-item-shrink">
						<span class="inline-item">
							<span class="loading-animation" role="presentation"></span>
						</span>
					</div>
					<div class="input-group-item input-group-item-shrink">
						<a class="component-action" href="#1" role="button">
							<svg class="lexicon-icon lexicon-icon-times-circle" focusable="false" role="presentation"></svg>
						</a>
					</div>
				</div>
			</div>
		</div>
	</div>
</div>
```

I just wrapped items in more divs. We might be able to sneak this in 2.x if no one is extending the Multiselect component.